### PR TITLE
adds replication_spec attribute to cluster resource

### DIFF
--- a/vendor/github.com/akshaykarle/go-mongodbatlas/mongodbatlas/clusters.go
+++ b/vendor/github.com/akshaykarle/go-mongodbatlas/mongodbatlas/clusters.go
@@ -24,6 +24,14 @@ type AutoScaling struct {
 	DiskGBEnabled bool `json:"diskGBEnabled"`
 }
 
+// ReplicationSpec describes a region’s priority in elections,
+// and the number and type of MongoDB nodes Atlas deploys to the region.
+type ReplicationSpec struct {
+	Priority       int `json:"priority"`
+	ElectableNodes int `json:"electableNodes"`
+	ReadOnlyNodes  int `json:"readOnlyNodes"`
+}
+
 // ProviderSettings is the configuration for the provisioned servers on which MongoDB runs.
 // The available options are specific to the cloud service provider.
 type ProviderSettings struct {
@@ -35,22 +43,23 @@ type ProviderSettings struct {
 
 // Cluster represents a Cluster configuration in MongoDB.
 type Cluster struct {
-	ID                  string           `json:"id,omitempty"`
-	GroupID             string           `json:"groupId,omitempty"`
-	Name                string           `json:"name,omitempty"`
-	MongoDBVersion      string           `json:"mongoDBVersion,omitempty"`
-	MongoDBMajorVersion string           `json:"mongoDBMajorVersion,omitempty"`
-	MongoURI            string           `json:"mongoURI,omitempty"`
-	MongoURIUpdated     string           `json:"mongoURIUpdated,omitempty"`
-	MongoURIWithOptions string           `json:"mongoURIWithOptions,omitempty"`
-	DiskSizeGB          float64          `json:"diskSizeGB,omitempty"`
-	BackupEnabled       bool             `json:"backupEnabled"`
-	StateName           string           `json:"stateName,omitempty"`
-	ReplicationFactor   int              `json:"replicationFactor,omitempty"`
-	NumShards           int              `json:"numShards,omitempty"`
-	Paused              bool             `json:"paused"`
-	AutoScaling         AutoScaling      `json:"autoScaling,omitempty"`
-	ProviderSettings    ProviderSettings `json:"providerSettings,omitempty"`
+	ID                  string                     `json:"id,omitempty"`
+	GroupID             string                     `json:"groupId,omitempty"`
+	Name                string                     `json:"name,omitempty"`
+	MongoDBVersion      string                     `json:"mongoDBVersion,omitempty"`
+	MongoDBMajorVersion string                     `json:"mongoDBMajorVersion,omitempty"`
+	MongoURI            string                     `json:"mongoURI,omitempty"`
+	MongoURIUpdated     string                     `json:"mongoURIUpdated,omitempty"`
+	MongoURIWithOptions string                     `json:"mongoURIWithOptions,omitempty"`
+	DiskSizeGB          float64                    `json:"diskSizeGB,omitempty"`
+	BackupEnabled       bool                       `json:"backupEnabled"`
+	StateName           string                     `json:"stateName,omitempty"`
+	ReplicationFactor   int                        `json:"replicationFactor,omitempty"`
+	ReplicationSpec     map[string]ReplicationSpec `json:"replicationSpec,omitempty"`
+	NumShards           int                        `json:"numShards,omitempty"`
+	Paused              bool                       `json:"paused"`
+	AutoScaling         AutoScaling                `json:"autoScaling,omitempty"`
+	ProviderSettings    ProviderSettings           `json:"providerSettings,omitempty"`
 }
 
 // clusterListResponse is the response from the ClusterService.List.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -16,10 +16,10 @@
 			"revisionTime": "2018-01-04T19:21:51Z"
 		},
 		{
-			"checksumSHA1": "mESyX1MqQvWdZCtn3kJSEljjKoo=",
+			"checksumSHA1": "sLelpIo29D7uHstQ0ALCplFCGFU=",
 			"path": "github.com/akshaykarle/go-mongodbatlas/mongodbatlas",
-			"revision": "b26ef4a3d81be4d9e78e85de07085346724189ff",
-			"revisionTime": "2018-03-24T20:24:22Z",
+			"revision": "ceae5a5351cbd416279db321151fed119374cd04",
+			"revisionTime": "2018-06-06T17:05:32Z",
 			"tree": true
 		},
 		{


### PR DESCRIPTION
Adds a `replication_spec` attribute to the mongodbatlas_cluster resource.

Example:
```hcl
  replication_spec = [{
      region          = "US_WEST_1"
      priority        = 5
      electable_nodes = 2
      read_only_nodes = 0
  }]
```

The build won't pass until this is merged: https://github.com/akshaykarle/go-mongodbatlas/pull/2