### PR TITLE
Fix parameter order in log messages

### DIFF
--- a/mongodbatlas/cluster.go
+++ b/mongodbatlas/cluster.go
@@ -366,7 +366,7 @@ func resourceClusterImportState(d *schema.ResourceData, meta interface{}) ([]*sc
 
 	c, _, err := client.Clusters.Get(gid, name)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't import cluster %s in group %s, error: %s", gid, name, err.Error())
+		return nil, fmt.Errorf("Couldn't import cluster %s in group %s, error: %s", name, gid, err.Error())
 	}
 
 	d.SetId(c.ID)

--- a/mongodbatlas/database_user.go
+++ b/mongodbatlas/database_user.go
@@ -160,7 +160,7 @@ func resourceDatabaseUserImportState(d *schema.ResourceData, meta interface{}) (
 
 	u, _, err := client.DatabaseUsers.Get(gid, username)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't import user %s in group %s, error: %s", gid, username, err.Error())
+		return nil, fmt.Errorf("Couldn't import user %s in group %s, error: %s", username, gid, err.Error())
 	}
 
 	d.SetId(u.Username)

--- a/mongodbatlas/ip_whitelist.go
+++ b/mongodbatlas/ip_whitelist.go
@@ -123,7 +123,7 @@ func resourceIPWhiteListImportState(d *schema.ResourceData, meta interface{}) ([
 
 	ip, _, err := client.Whitelist.Get(gid, cidr)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't import ip whitelist %s in group %s, error: %s", gid, cidr, err.Error())
+		return nil, fmt.Errorf("Couldn't import ip whitelist %s in group %s, error: %s", cidr, gid, err.Error())
 	}
 
 	d.SetId(ip.CidrBlock)


### PR DESCRIPTION
I realized I'd swapped the parameters when I added the group ID to the log messages in the last PR, fixed now.