### PR TITLE
Allow IP whitelist comment to be updated

### DIFF
--- a/mongodbatlas/ip_whitelist.go
+++ b/mongodbatlas/ip_whitelist.go
@@ -28,10 +28,11 @@ func resourceIPWhitelist() *schema.Resource {
 				ForceNew: true,
 			},
 			"cidr_block": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"ip_address"},
 			},
 			"ip_address": &schema.Schema{
 				Type:          schema.TypeString,
@@ -53,6 +54,11 @@ func resourceIPWhitelistCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ma.Client)
 	cidrBlock := d.Get("cidr_block").(string)
 	ip := d.Get("ip_address").(string)
+
+	if cidrBlock != "" && ip != "" {
+		// cidrBlock & ip are mutually exclusive, use cidrBlock if both are set
+		ip = ""
+	}
 
 	params := []ma.Whitelist{
 		ma.Whitelist{
@@ -96,7 +102,7 @@ func resourceIPWhitelistRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIPWhitelistUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	return resourceIPWhitelistCreate(d, meta)
 }
 
 func resourceIPWhitelistDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This allows the IP whitelist resource to be updated (you can only update the comment really, anything else will trigger a destroy + create due to `ForceNew` being set).

The update endpoint uses a `POST` and not a `PUT` so I just reused the create method. I added a small guard to make sure ip & cidr block aren't both set in the update case.