### PR TITLE
Fix project's cluster_count

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -25,7 +25,7 @@ func dataSourceProject() *schema.Resource {
 				Computed: true,
 			},
 			"cluster_count": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -30,7 +30,7 @@ func resourceProject() *schema.Resource {
 				Computed: true,
 			},
 			"cluster_count": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
It wasn't being set as `go-mongodbatlas` returns an int for  `cluster_count`.