### PR TITLE
Fix for disk_size_gb diff. #32, #34

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -71,6 +71,7 @@ func resourceCluster() *schema.Resource {
 			"disk_size_gb": &schema.Schema{
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Computed: true,
 			},
 			"replication_factor": &schema.Schema{
 				Type:     schema.TypeInt,


### PR DESCRIPTION
As first reported in issue #32 and attempted fix in #34: not setting `disk_size_gb` causes a diff to be generated each run wanting to set the size to 0. Current workarounds of specifying `disk_size_gb` or `ignore_changes` are not ideal.

Setting `disk_size_gb` as `Computed` means a plan diff is no longer generated. This was first suggested by @ mmindenhall in #34 and appears to work correctly.

I tried:
- a shared tier cluster and default disk size
- An M10 cluster with default disk size
- An M30 cluster with custom disk size, and then removed `disk_size_gb`. Provider still didn't want to modify disk size :)