### PR TITLE
Add terraform website documentation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -59,6 +59,13 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
 	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
 endif
+	# For testing until an official provider
+	if [ ! -h $(GOPATH)/src/$(WEBSITE_REPO)/content/source/docs/providers/mongodbatlas ]; then \
+		ln -s ../../../../ext/providers/mongodbatlas/website/docs/ $(GOPATH)/src/$(WEBSITE_REPO)/content/source/docs/providers/mongodbatlas; \
+	fi
+	if [ ! -h $(GOPATH)/src/$(WEBSITE_REPO)/content/source/layouts/mongodbatlas.erb ]; then \
+		ln -s ../../../../ext/providers/mongodbatlas/website/mongodbatlas.erb $(GOPATH)/src/$(WEBSITE_REPO)/content/source/layouts/mongodbatlas.erb; \
+	fi
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 website-test:
@@ -66,7 +73,13 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
 	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
 endif
+	# For testing until an official provider
+	if [ ! -h $(GOPATH)/src/$(WEBSITE_REPO)/content/source/docs/providers/mongodbatlas ]; then \
+		ln -s ../../../../ext/providers/mongodbatlas/website/docs/ $(GOPATH)/src/$(WEBSITE_REPO)/content/source/docs/providers/mongodbatlas; \
+	fi
+	if [ ! -h $(GOPATH)/src/$(WEBSITE_REPO)/content/source/layouts/mongodbatlas.erb ]; then \
+		ln -s ../../../../ext/providers/mongodbatlas/website/mongodbatlas.erb $(GOPATH)/src/$(WEBSITE_REPO)/content/source/layouts/mongodbatlas.erb; \
+	fi
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile
-
+.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test

--- a/website/docs/d/container.html.markdown
+++ b/website/docs/d/container.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: container"
+sidebar_current: "docs-mongodbatlas-datasource-container"
+description: |-
+    Provides details about a specific Container
+---
+
+# Data Source: mongodbatlas_container
+
+`mongodbatlas_container` provides details about a specific Container. This represents an AWS VPC in MongoDB Atlas's network for use in VPC Peering.
+
+This data source can prove useful when looking up the details of a previously created Container.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+data "mongodbatlas_container" "example" {
+  group      = "${data.mongodbatlas_project.project.id}"
+  identifier = "1112222b3bf99403840e8934"
+}
+```
+
+## Argument Reference
+
+* `group` - (Required) The ID of the project that the desired container belongs to.
+* `identifier` - (Required) The ID of the desired container.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The same as `identifier`.
+* `atlas_cidr_block` - CIDR block of the Container.
+* `provider_name` - Name of provider hosting the Container. e.g. `AWS`.
+* `provisioned` - Flag that indicates if the backing VPC has been created.
+* `region` - Atlas-style name of region containing the Container. e.g. `US_EAST_1`
+* `vpc_id` - The ID of the project's VPC. This may be empty when `provisioned` is `false`

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: project"
+sidebar_current: "docs-mongodbatlas-datasource-project"
+description: |-
+    Provides details about a specific Project
+---
+
+# Data Source: mongodbatlas_project
+
+`mongodbatlas_project` provides details about a specific Project.
+
+This data source can prove useful when looking up the details of a previously created Project.
+
+~> **NOTE:** An error will be thrown if there are multiple projects with the same name in different Organizations accessible by the user.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the desired project.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id of the project. Used for `group` arguments in resources.
+* `cluster_count` - The number of Atlas clusters deployed in the project.
+* `created` - The ISO-8601 formatted timestamp of when Atlas created the project.
+* `org_id` - The ID of the owning organization.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,84 @@
+---
+layout: "mongodbatlas"
+page_title: "Provider: mongodbatlas"
+sidebar_current: "docs-mongodbatlas-index"
+description: |-
+  The MongoDB Atlas provider is used to interact with the resources supported by MongoDB's Atlas service. The provider needs to be configured with the proper credentials before it can be used.
+---
+
+# MongoDB Atlas Provider
+
+The MongoDB Atlas provider is used to interact with the resources supported by
+MongoDB's Atlas service. The provider needs to be configured with the proper
+credentials before it can be used.
+
+Use the nagivation to the left to read about the available resources.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on
+resources are the project ID.
+
+## Example Usage
+
+```hcl
+# Configure the MongoDB Atlas Provider
+provider "mongodbatlas" {
+  username = "${var.mongodb_atlas_username}"
+  api_key  = "${var.mongodb_atlas_api_key}"
+}
+
+# Create a cluster
+resource "mongodbatlas_cluster" "cluster" {
+  # ...
+}
+```
+
+## Authentication
+
+The MongoDB Atlas Provider can either be configured with static credentials or
+environment variables for authentication. Static credentials override
+environment variables.
+
+### Static credentials
+
+Static credentials can be provided by adding `username` and `api_key` in-line in the MongoDB Atlas provider block:
+
+Usage:
+
+```hcl
+provider "mongodbatlas" {
+  username = "username"
+  api_key  = "api_key"
+}
+```
+
+### Environment variables
+
+You can provide your credentials via the `MONGODB_ATLAS_USERNAME` and
+`MONGODB_ATLAS_API_KEY` environment variables:
+
+```hcl
+provider "mongodbatlas" {}
+```
+
+Usage:
+
+```shell
+$ export MONGODB_ATLAS_USERNAME="username"
+$ export MONGODB_ATLAS_API_KEY="api_key"
+$ terraform plan
+```
+
+## Argument Reference
+
+In addition to [generic `provider`
+arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
+`alias` and `version`), the following arguments are supported in the MongoDB
+Atlas `provider` block:
+
+* `api_key` - (Optional) This is the MongoDB Atlas API key. It must be
+  provided, but it can also be sourced from the `MONGODB_ATLAS_API_KEY`
+  environment variable.
+
+* `username` - (Optional) This is the MongoDB Atlas username. It must be
+  provided, but it can also be sourced from the `MONGODB_ATLAS_USERNAME`
+  environment variable.

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -1,0 +1,149 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: cluster"
+sidebar_current: "docs-mongodbatlas-resource-cluster"
+description: |-
+    Provides a Cluster resource.
+---
+
+# mongodbatlas_cluster
+
+`mongodbatlas_cluster` provides a Cluster resource.
+
+-> **NOTE:** M0 (Free tier) clusters cannot be created via the API. See [Atlas M0 (Free Tier), M2, and M5 Limitations](https://docs.atlas.mongodb.com/reference/free-shared-limitations/) for more free and shared tier limitations.
+
+-> **NOTE:** AWS users: create a [mongodbatlas_container](/docs/providers/mongodbatlas/r/container.html) in the region first if you are creating M10+ clusters and want to use VPC peering.
+
+-> **NOTE:** The provider does not currently support [Global Clusters](https://docs.atlas.mongodb.com/global-clusters/).
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+Shared tenancy tier cluster:
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+resource "mongodbatlas_cluster" "cluster" {
+  name                  = "example-tenant"
+  group                 = "${data.mongodbatlas_project.project.id}"
+  mongodb_major_version = "3.6"
+  provider_name         = "TENANT"
+  backing_provider      = "AWS"
+  region                = "US_EAST_1"
+  size                  = "M2"
+  backup                = false
+  disk_gb_enabled       = false
+  disk_size_gb          = 2
+}
+```
+
+Single region cluster:
+
+```hcl
+resource "mongodbatlas_cluster" "cluster" {
+  name                  = "example-single"
+  group                 = "${data.mongodbatlas_project.project.id}"
+  mongodb_major_version = "3.4"
+  provider_name         = "GCP"
+  region                = "CENTRAL_US"
+  size                  = "M40"
+  backup                = true
+  disk_gb_enabled       = true
+}
+```
+
+Multi-region cluster:
+
+```hcl
+resource "mongodbatlas_cluster" "cluster" {
+  name                  = "example-multi"
+  group                 = "${data.mongodbatlas_project.project.id}"
+  mongodb_major_version = "3.4"
+  provider_name         = "AZURE"
+  region                = ""
+  size                  = "M20"
+  backup                = false
+  replication_factor    = 0
+
+  replication_spec {
+    region          = "US_WEST"
+    priority        = 7
+    electable_nodes = 3
+  }
+
+  replication_spec {
+    region          = "US_CENTRAL"
+    priority        = 6
+    electable_nodes = 2
+  }
+
+  replication_spec {
+    region          = "US_EAST_2"
+    priority        = 5
+    electable_nodes = 2
+    read_only_nodes = 2
+  }
+}
+```
+
+## Argument Reference
+
+* `backing_provider` - (Optional) The cloud service provider for a shared tier cluster. One of `AWS`, `GCP` or `AZURE`. Only valid when `provider_name` is `TENANT`. Only `M2` and `M5` size clusters supported.
+* `backup` - (Required) Enable continuous backups.
+* `disk_gb_enabled` - (Optional) Enable disk auto-scaling. Defaults `true`.
+* `disk_size_gb` - (Optional) AWS/GCP only. Size in GB of the server's root volume. Minimum 10. Maximum is the smaller of: instance RAM * 50 or 4096. Default value depends on instance size. See [Create a Cluster](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/) `providerSettings.instanceSizeName` for default values.
+* `group` - (Required) The ID of the project in which to create the cluster.
+* `mongodb_major_version` - (Required) Version of the cluster to deploy. See [Create New Cluster](https://docs.atlas.mongodb.com/create-new-cluster/#select-the-mongodb-version-of-the-cluster) "Select the MongoDB Version of the Cluster" for valid versions.
+* `name` - (Required) Name of the cluster.
+* `num_shards` - (Optional) Set to greater than 1 to create a sharded cluster. Default 1, replica set.
+
+-> **NOTE:** A sharded cluster cannot be converted to a replica set.
+
+* `paused` - (Optional) Flag that indicates whether the cluster is paused. Defaults false.
+
+-> **NOTE:** You cannot create a cluster as `paused`.
+
+* `provider_name` - (Required) Name of the cloud provider. Current values are: `AWS`, `GCP`, `AZURE` and `TENANT`. `TENANT` also requires setting `backing_provider`.
+* `region` - (Required) Atlas-style name of the region in which to create the cluster. e.g. `US_EAST_1`. See [Create a Cluster](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/), `providerSettings.regionName`, for valid values. **Note:** Set to an empty string if specifying multiple `replication_spec` blocks.
+* `replication_factor` - (Optional) Number of replica set members. Each shard is a replica set with the specified replication factor if a sharded cluster. Ignored if `replication_spec` is used. Possible values of 3, 5, or 7. Default 3. **Note:** Set to 0 if specifying multiple `replication_spec` blocks.
+* `replication_spec` - (Optional) Configuration of each region in a multi-region cluster. See [Replication Spec](#replication-spec) below for more details.
+* `size` - (Required) Instance size of all data-bearing servers in the cluster.  See [Create a Cluster](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/) `providerSettings.instanceSizeName` for valid values and default resources.
+
+### Replication Spec
+
+The configuration of each region in a multi-region cluster.
+
+* `electable_nodes` - (Required) Number of electable nodes to deploy to the region. Electable nodes can become the primary and can facilitate local reads. Total number of electable nodes across all regions in the cluster must be 3, 5, or 7. Specify 0 to not have electable nodes in the region. Electable nodes cannot be created if `priority` is 0.
+* `priority` - (Required) Election priority of the region. Set to 0 for regions only containing read-only nodes. The first region defined with electable nodes **must** have a `priority` of 7. Following regions with electable nodes must have a priority of one less than the previous. Lowest possible priority is 1. For example, with three regions, the priorities would be: 7, 6 and 5.
+* `read_only_nodes` - (Optional) Number of read-only nodes in the region. Read-only nodes can never become the primary but can facilitate local-reads. Default 0.
+* `region` - (Required) Atlas-style name of the region in which to create the replica. See [Create a Cluster](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/), `providerSettings.regionName`, for valid values.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The container ID.
+* `identifier` - The same as `id`.
+* `mongodb_version` - Version of MongoDB deployed. Major.Minor.Patch.
+* `mongo_uri` - Base connection string for the cluster. See `mongo_uri_with_options` for a more usable connection string.
+* `mongo_uri_updated` - When the connection string was last updated. Connection string changes, for example, if you change a replica set to a sharded cluster.
+* `mongo_uri_with_options` - Connection string for connecting to the Atlas cluster. Includes necessary query parameters with values appropriate for the cluster. Include a username and password for a MongoDB user associated with the project after the `mongodb://` to actually connect. See [mongodbatlas_database_user](/docs/providers/mongodbatlas/r/database_user.html) for creating users.
+* `state` - Current state of the cluster. Possible states are:
+  * IDLE
+  * CREATING
+  * UPDATING
+  * DELETING
+  * DELETED
+  * REPAIRING
+
+## Import
+
+Clusters can be imported using project ID and cluster name, in the format `PROJECTID-CLUSTERNAME`, e.g.
+
+```
+$ terraform import mongodbatlas_cluster.my_cluster 1112222b3bf99403840e8934-Cluster0
+```

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: container"
+sidebar_current: "docs-mongodbatlas-resource-container"
+description: |-
+    Provides a Container resource.
+---
+
+# mongodbatlas_container
+
+`mongodbatlas_container` provides a Container resource. This represents an AWS VPC in MongoDB Atlas's network for use in VPC Peering.
+
+~> **NOTE:** Only one Container can exist within a Project for each region. The provider allows you to define multiple container resources within the same project and region but this may lead to constant updates of the resources.
+
+-> **NOTE:** The provider does not currently support deleting Containers due to a limitation in MongoDB Atlas's API.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+resource "mongodbatlas_container" "container" {
+  group            = "${data.mongodbatlas_project.project.id}"
+  atlas_cidr_block = "10.0.0.0/21"
+  provider_name    = "AWS"
+  region           = "US_EAST_1"
+}
+
+resource "mongodbatlas_cluster" "cluster" {
+  group         = "${data.mongodbatlas_project.project.id}"
+  provider_name = "AWS"
+  region        = "US_EAST_1"
+  size          = "M10"
+  # ...
+  depends_on = ["mongodbatlas_container.container"]
+}
+```
+
+## Argument Reference
+
+* `atlas_cidr_block` - (Required) CIDR block for the Atlas VPC in the Project region. This must be at least a /24 and at most a /21 in one of the following private networks:
+  * 10.0.0.0/8
+  * 172.16.0.0/12
+  * 192.168.0.0/16
+
+~> **NOTE:** The `atlas_cidr_block` value cannot be set or changed if an M10+ or VPC peering connection already exists in the Project region. To modify the CIDR block, remove all M10+ clusters and peering connections from the region, or use a new Project.
+
+~> **NOTE:** The `atlas_cidr_block` must not overlap with containers in other regions, or with any VPC peering connections, of the Project.
+
+-> **NOTE:** The size of the CIDR block affects the number of MongoDB nodes per container. See "Atlas CIDR Block" in the [official documentation](https://docs.atlas.mongodb.com/security-vpc-peering/)
+
+* `group` - (Required) The ID of the project in which to create the container.
+* `provider_name` - (Required) Name of the cloud provider. Currently only `AWS` is supported.
+* `region` - (Required) Atlas-style name of the region in which to create the container. e.g. `US_EAST_1`. See [official documentation](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/), `providerSettings.regionName`, for valid values.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The container ID.
+* `identifier` - The same as `id`.
+* `provisioned` - Flag that indicates if the backing VPC has been created.
+* `vpc_id` - The ID of the project's VPC. This will be empty when `provisioned` is `false`
+
+## Import
+
+There is no need to import a container. Define a resource in the same project and region to adopt or modify the existing container.

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: database_user"
+sidebar_current: "docs-mongodbatlas-resource-database_user"
+description: |-
+    Provides a Database User resource.
+---
+
+# mongodbatlas_database_user
+
+`mongodbatlas_database_user` provides a Database User resource. This represents a database user which will be applied to all clusters within the project.
+
+User's roles can be restricted to specific databases. If two clusters in the project have the same database name, the role will apply to both clusters and databases.
+
+~> **NOTE:** All arguments including the password will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html)
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+resource "mongodbatlas_database_user" "test" {
+  username = "test"
+  password = "initial_password"
+  database = "admin"
+  group    = "${data.mongodbatlas_project.project.id}"
+
+  roles {
+    name     = "read"
+    database = "admin"
+  }
+
+  roles {
+    name     = "readWrite"
+    database = "mydatabase"
+  }
+}
+```
+
+## Argument Reference
+
+* `database` - (Required) The user's authentication database. In MongoDB Atlas this is always the `admin` database.
+* `group` - (Required) The ID of the project in which to create the database user.
+* `password` - (Optional) User's initial password. This is required to create the user but may be removed after.
+
+~> **NOTE:** Password may show up in logs, and it will be stored in the state file as plain-text. Password can be changed in the web interface to increase security.
+
+* `roles` - (Required) Roles to grant on individual databases and collections. See [Roles](#roles) below for more details.
+* `username` - (Required) Name of the database user.
+
+### Roles
+
+Block mapping a user's role to a database. A role grants actions on the given database. A role on the `admin` database can include privileges that apply to other databases.
+
+* `name` - (Required) Name of the role to grant. See [Create a Database User](https://docs.atlas.mongodb.com/reference/api/database-users-create-a-user/) `roles.roleName` for valid values and restrictions.
+* `database` - (Required) Name of database on which to grant role `name`.
+* `collection` - (Optional) Collection for which the role applies. Only valid when `name` is set to `read` or `readWrite`. Role applies to all collections in the `database` if `collection` is not specified.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The database user's name.
+
+## Import
+
+Database users can be imported using project ID and username, in the format `PROJECTID-USERNAME`, e.g.
+
+```
+$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user
+```
+
+~> **NOTE:** Terraform will want to change the password after importing the user if a `password` argument is specified.

--- a/website/docs/r/ip_whitelist.html.markdown
+++ b/website/docs/r/ip_whitelist.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: ip_whitelist"
+sidebar_current: "docs-mongodbatlas-resource-ip_whitelist"
+description: |-
+    Provides an IP Whitelist resource.
+---
+
+# mongodbatlas_ip_whitelist
+
+`mongodbatlas_ip_whitelist` provides an IP Whitelist entry resource. The whitelist grants access from IPs or CIDRs to clusters within the Project.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+resource "mongodbatlas_ip_whitelist" "cidr" {
+  group      = "${data.mongodbatlas_project.project.id}"
+  cidr_block = "10.0.0.0/21"
+  comment    = "cidr"
+}
+
+resource "mongodbatlas_ip_whitelist" "ip" {
+  group      = "${data.mongodbatlas_project.project.id}"
+  ip_address = "10.10.10.10"
+  comment    = "ip"
+}
+```
+
+## Argument Reference
+
+* `cidr_block` - (Optional) CIDR block from which to grant access. One of `cidr_block` or `ip_address` must be specified.
+* `comment` - (Optional) Comment to add to the whitelist entry.
+* `group` - (Required) The ID of the project in which to add the whitelist entry.
+* `ip_address` - (Optional) IP address from which to grant access. One of `cidr_block` or `ip_address` must be specified.
+
+-> **NOTE:** The web interface allows the use of AWS security groups in the whitelist when used with VPC peering. Unfortunately there is currently a bug in the API that makes this feature incompatible with the provider. Support says they have no time frame to fix the bug as of 2018-09-12.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The container ID.
+
+## Import
+
+IP Whitelist entries can be imported using project ID and CIDR or IP, in the format `PROJECTID-CIDR`, e.g.
+
+```
+$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-10.0.0.0/24
+```

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: project"
+sidebar_current: "docs-mongodbatlas-resource-project"
+description: |-
+    Provides a Project resource.
+---
+
+# mongodbatlas_project
+
+`mongodbatlas_project` provides a Project resource. This allows projects to be created.
+
+-> **NOTE:** The provider does not currently support deleting Projects.
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_project" "project" {
+  org_id = "${var.mongodb_atlas_org_id}"
+  name   = "my-project"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the desired project.
+
+~> **NOTE:** Changing `name` causes the provider to create a new project. Dependent resources may also be recreated.
+
+* `org_id` - (Required) ID of the organization in which to create the project.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id of the project. Used for `group` arguments in resources.
+* `cluster_count` - The number of Atlas clusters deployed in the project.
+* `created` - The ISO-8601 formatted timestamp of when Atlas created the project.

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -1,0 +1,83 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: vpc_peering_connection"
+sidebar_current: "docs-mongodbatlas-resource-vpc_peering_connection"
+description: |-
+    Provides a VPC Peering Connection resource.
+---
+
+# mongodbatlas_vpc_peering_connection
+
+`mongodbatlas_vpc_peering_connection` provides a VPC Peering Connection resource. This creates a peering request to other AWS VPCs.
+
+Enable DNS hostnames and DNS resolution in the peer VPC. Resources can then connect to MongoDB Atlas clusters in the same region via private IP addresses using DNS names. See [Updating DNS Support](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html#vpc-dns-updating) for how to enable these options.
+
+MongoDB Atlas only supports VPC peering with AWS VPCs in the same region. For multi-region clusters, you must create VPC peering connections per-region. Only MongoDB nodes in the same region can be accessed over the VPC peering connection. Nodes in remote regions are still accessed via public IPs.
+
+Route table entries will need to be created in the AWS VPC for MongoDB clusters to be accessible via private IP. See [Updating Your Route Tables for a VPC Peering Connection](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) and [aws_route](/docs/providers/aws/r/route.html).
+
+-> **NOTE:** VPC Peering is not available for M0 (Free Tier), M2, and M5 clusters.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+resource "mongodbatlas_container" "container" {
+  group            = "${data.mongodbatlas_project.project.id}"
+  atlas_cidr_block = "10.0.0.0/21"
+  provider_name    = "AWS"
+  region           = "US_EAST_1"
+}
+
+resource "mongodbatlas_vpc_peering_connection" "peering" {
+  group                  = "${data.mongodbatlas_project.project.id}"
+  aws_account_id         = "111111111111"
+  vpc_id                 = "vpc-xxxxxxxxxxxxxxxxx"
+  route_table_cidr_block = "10.1.0.0/16"
+  container_id           = "${mongodbatlas_container.container.id}"
+}
+
+resource "aws_vpc_peering_connection_acceptor" "atlas" {
+  vpc_peering_connection_id = "${mongodbatlas_vpc_peering_connection.peering.connection_id}"
+  auto_accept               = true
+}
+```
+
+## Argument Reference
+
+* `aws_account_id` - (Required) AWS account ID of the owner of the peer VPC.
+* `container_id` - (Required) ID of the [`mongodbatlas_container`](/docs/providers/mongodbatlas/r/container.html).
+
+~> **NOTE:** The Atlas VPC container and the `vpc_id` peer VPC *must* share an AWS region.
+
+* `group` - (Required) The ID of the project in which to create the VPC peering connection.
+* `route_table_cidr_block` - (Required) The peer VPC CIDR block or subnet.
+* `vpc_id` - (Required) - The ID of the peer VPC.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Atlas resource ID.
+* `connection_id` - The AWS peering connection ID.
+* `error_state_name` - The error state, if any. May be one of the following:
+  * REJECTED
+  * EXPIRED
+  * INVALID\_ARGUMENT
+* `identifier` - The same as `id`.
+* `status_name` - Status name of the peering connection. May be one of the following:
+  * INITIATING
+  * PENDING\_ACCEPTANCE
+  * FAILED
+  * FINALIZING
+  * AVAILABLE
+  * TERMINATING

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -10,6 +10,16 @@
                     <a href="/docs/providers/mongodbatlas/index.html">MongoDB Atlas Provider</a>
                 </li>
 
+                <li<%= sidebar_current("docs-mongodbatlas-datasource") %>>
+                    <a href="#">Data Sources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-mongodbatlas-datasource-container") %>>
+                            <a href="/docs/providers/mongodbatlas/d/container.html">mongodbatlas_container</a>
+                        </li>
+                    </ul>
+                </li>
+
             </ul>
         </div>
     <% end %>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -35,6 +35,10 @@
                         <li<%= sidebar_current("docs-mongodbatlas-resource-project") %>>
                             <a href="/docs/providers/mongodbatlas/r/project.html">mongodbatlas_project</a>
                         </li>
+
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-vpc_peering_connection") %>>
+                            <a href="/docs/providers/mongodbatlas/r/vpc_peering_connection.html">mongodbatlas_vpc_peering_connection</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -36,6 +36,10 @@
                             <a href="/docs/providers/mongodbatlas/r/database_user.html">mongodbatlas_database_user</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-ip_whitelist") %>>
+                            <a href="/docs/providers/mongodbatlas/r/ip_whitelist.html">mongodbatlas_ip_whitelist</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-mongodbatlas-resource-project") %>>
                             <a href="/docs/providers/mongodbatlas/r/project.html">mongodbatlas_project</a>
                         </li>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -28,6 +28,10 @@
                     <a href="#">Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-cluster") %>>
+                            <a href="/docs/providers/mongodbatlas/r/cluster.html">mongodbatlas_cluster</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-mongodbatlas-resource-container") %>>
                             <a href="/docs/providers/mongodbatlas/r/container.html">mongodbatlas_container</a>
                         </li>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -28,6 +28,10 @@
                     <a href="#">Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-container") %>>
+                            <a href="/docs/providers/mongodbatlas/r/container.html">mongodbatlas_container</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-mongodbatlas-resource-project") %>>
                             <a href="/docs/providers/mongodbatlas/r/project.html">mongodbatlas_project</a>
                         </li>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -24,6 +24,16 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-mongodbatlas-resource") %>>
+                    <a href="#">Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-project") %>>
+                            <a href="/docs/providers/mongodbatlas/r/project.html">mongodbatlas_project</a>
+                        </li>
+                    </ul>
+                </li>
+
             </ul>
         </div>
     <% end %>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -1,0 +1,18 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complementary">
+            <ul class="nav docs-sidenav">
+                <li <%= sidebar_current("docs-home") %>>
+                    <a href="/docs/providers/index.html">All Providers</a>
+                </li>
+
+                <li<%= sidebar_current("docs-mongodbatlas-index") %>>
+                    <a href="/docs/providers/mongodbatlas/index.html">MongoDB Atlas Provider</a>
+                </li>
+
+            </ul>
+        </div>
+    <% end %>
+
+    <%= yield %>
+<% end %>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -32,6 +32,10 @@
                             <a href="/docs/providers/mongodbatlas/r/container.html">mongodbatlas_container</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-mongodbatlas-resource-database_user") %>>
+                            <a href="/docs/providers/mongodbatlas/r/database_user.html">mongodbatlas_database_user</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-mongodbatlas-resource-project") %>>
                             <a href="/docs/providers/mongodbatlas/r/project.html">mongodbatlas_project</a>
                         </li>

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -17,6 +17,10 @@
                         <li<%= sidebar_current("docs-mongodbatlas-datasource-container") %>>
                             <a href="/docs/providers/mongodbatlas/d/container.html">mongodbatlas_container</a>
                         </li>
+
+                        <li<%= sidebar_current("docs-mongodbatlas-datasource-project") %>>
+                            <a href="/docs/providers/mongodbatlas/d/project.html">mongodbatlas_project</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
Upon trying to use the provider I found myself reading the provider source code, Atlas docs and Atlas API docs.

I've written terraform website style documentation to save the next person some time. These aren't full replacements for the official docs and do contain references to them.

I'm not an editor and have read through these pages so many times now that I can't see straight.

Hopefully will help with issue #27