### PR TITLE
Use mutex on IP Whitelist delete

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_ip_whitelist.go
+++ b/mongodbatlas/resource_mongodbatlas_ip_whitelist.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 )
 
-var createMutex = &sync.Mutex{}
+var apiMutex = &sync.Mutex{}
 
 func resourceIPWhitelist() *schema.Resource {
 	return &schema.Resource{
@@ -54,8 +54,8 @@ func resourceIPWhitelist() *schema.Resource {
 }
 
 func resourceIPWhitelistCreate(d *schema.ResourceData, meta interface{}) error {
-	createMutex.Lock()
-	defer createMutex.Unlock()
+	apiMutex.Lock()
+	defer apiMutex.Unlock()
 
 	client := meta.(*ma.Client)
 	cidrBlock := d.Get("cidr_block").(string)
@@ -112,6 +112,9 @@ func resourceIPWhitelistUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIPWhitelistDelete(d *schema.ResourceData, meta interface{}) error {
+	apiMutex.Lock()
+	defer apiMutex.Unlock()
+
 	client := meta.(*ma.Client)
 
 	log.Printf("[DEBUG] MongoDB Project IP Whitelist destroy: %v", d.Id())


### PR DESCRIPTION
I filed an earlier issue (#31), which was fixed with PR #33.  The fix in #33 introduced a mutex on IP Whitelist create operations to enforce sequential API calls.  We also see that during terraform destroy of our environment, some IP Whitelist entries are not deleted.  I suspect it's the same problem as with the create (i.e., race condition in the Atlas API), so I added the mutex to delete operations as well.