### PR TITLE
Cluster data source

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -1,0 +1,168 @@
+package mongodbatlas
+
+import (
+	"fmt"
+
+	ma "github.com/akshaykarle/go-mongodbatlas/mongodbatlas"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mongodb_major_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"provider_backup": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"size": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provider_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backing_provider": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_size_gb": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"replication_factor": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"num_shards": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"paused": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"disk_gb_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"identifier": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongodb_version": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri_updated": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri_with_options": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replication_spec": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"electable_nodes": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"read_only_nodes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ma.Client)
+	group := d.Get("group").(string)
+	name := d.Get("name").(string)
+	c, _, err := client.Clusters.Get(group, name)
+	if err != nil {
+		return fmt.Errorf("Error reading MongoDB Cluster with name %s: %s", name, err)
+	}
+	replicationSpecs := []interface{}{}
+	for region, replicationSpec := range c.ReplicationSpec {
+		spec := map[string]interface{}{
+			"region":          region,
+			"priority":        replicationSpec.Priority,
+			"electable_nodes": replicationSpec.ElectableNodes,
+			"read_only_nodes": replicationSpec.ReadOnlyNodes,
+		}
+		replicationSpecs = append(replicationSpecs, spec)
+	}
+
+	d.SetId(c.ID)
+	d.Set("name", c.Name)
+	d.Set("group", c.GroupID)
+	d.Set("mongodb_major_version", c.MongoDBMajorVersion)
+	d.Set("backup", c.BackupEnabled)
+	d.Set("provider_backup", c.ProviderBackupEnabled)
+	d.Set("size", c.ProviderSettings.InstanceSizeName)
+	d.Set("provider_name", c.ProviderSettings.ProviderName)
+	d.Set("backing_provider", c.ProviderSettings.BackingProviderName)
+	d.Set("region", c.ProviderSettings.RegionName)
+	d.Set("disk_size_gb", c.DiskSizeGB)
+	d.Set("disk_gb_enabled", c.AutoScaling.DiskGBEnabled)
+	d.Set("replication_factor", c.ReplicationFactor)
+	d.Set("state", c.StateName)
+	d.Set("num_shards", c.NumShards)
+	d.Set("paused", c.Paused)
+	d.Set("mongodb_version", c.MongoDBVersion)
+	d.Set("mongo_uri", c.MongoURI)
+	d.Set("mongo_uri_updated", c.MongoURIUpdated)
+	d.Set("mongo_uri_with_options", c.MongoURIWithOptions)
+	d.Set("replication_spec", replicationSpecs)
+
+	return nil
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"mongodbatlas_project":   dataSourceProject(),
 			"mongodbatlas_container": dataSourceContainer(),
+			"mongodbatlas_cluster":   dataSourceCluster(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: cluster"
+sidebar_current: "docs-mongodbatlas-datasource-cluster"
+description: |-
+    Provides details about a specific Cluster
+---
+
+# Data Source: mongodbatlas_cluster
+
+`mongodbatlas_cluster` provides details about a specific Cluster.
+
+This data source can prove useful when looking up the details of a previously created Cluster.
+
+-> **NOTE:** Groups and projects are synonymous terms. `group` arguments on resources are the project ID.
+
+## Example Usage
+
+```hcl
+data "mongodbatlas_project" "project" {
+  name = "my-project"
+}
+
+data "mongodbatlas_cluster" "example" {
+  group      = "${data.mongodbatlas_project.project.id}"
+  name = "my-cluster-name"
+}
+```
+
+## Argument Reference
+
+* `group` - (Required) The ID of the project that the desired cluster belongs to.
+* `identifier` - (Required) The name of the desired cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The same as `identifier`.
+* `mongodb_major_version` - Version of the cluster.
+* `backup` - If continuous backups are enabled.
+* `provider_backup` - If cloud provider snapshots are enabled.
+* `size` - Instance size of all data-bearing servers in the cluster.
+* `provider_name` - Name of the cloud provider. One of: `AWS`, `GCP`, `AZURE`, `TENANT`.
+* `backing_provider` - The cloud service provider for a shared tier cluster. One of `AWS`, `GCP`, `AZURE`.
+* `region` - Atlas-style name of the region in which the cluster was created. e.g. `US_EAST_1`.
+* `disk_size_gb` - AWS/GCP only. Size in GB of the server's root volume.
+* `disk_gb_enabled` - If disk auto-scaling is enabled.
+* `replication_factor` - Number of replica set members. Each shard is a replica set with the specified replication factor if a sharded cluster.
+* `state` - Current state of the cluster. One of: `IDLE`, `CREATING`,
+    `UPDATING`, `DELETING`, `DELETED`, `REPAIRING`.
+* `num_shards` - The number of active shards.
+* `paused` - Flag that indicates whether the cluster is paused.
+* `mongodb_version` - Version of MongoDB deployed. Major.Minor.Patch.
+* `mongo_uri` - Base connection string for the cluster. See `mongo_uri_with_options` for a more usable connection string.
+* `mongo_uri_updated` - When the connection string was last updated. Connection string changes, for example, if you change a replica set to a sharded cluster.
+* `mongo_uri_with_options` - Connection string for connecting to the Atlas cluster. Includes necessary query parameters with values appropriate for the cluster. Include a username and password for a MongoDB user associated with the project after the `mongodb://` to actually connect.


### PR DESCRIPTION
Hi, first of all thanks for creating this provider. It is a huge help for our automated infrastructure provisioning. 

Nevertheless we needed the cluster as a data source as well. Otherwise we have to apply the cluster creation together with the creation of other resources, because we needed the `mongodb_uri_with_options` as an env paremeter for a ec2 user_data script. This would have the drawback, that every time we want to destroy the ec2 instance, the mongodb cluster was destroyed as well, which results in long test iteration cycles. 

Here I created the data source and the documentation for it. But I couldn't write the test, because I always get an error while executing `make test`:  
```
=== RUN   TestAccMongodbatlasCluster_basic
SIGQUIT: quit
PC=0x489c31 m=0 sigcode=0

goroutine 0 [idle]:
runtime.futex(0x1b054c0, 0x80, 0x0, 0x0, 0x0, 0xc00064d800, 0x0, 0x0, 0x7ffd1e94c020, 0x434052, ...)
        /usr/lib/go/src/runtime/sys_linux_amd64.s:531 +0x21
runtime.futexsleep(0x1b054c0, 0xc000000000, 0xffffffffffffffff)
        /usr/lib/go/src/runtime/os_linux.go:46 +0x4b
runtime.notesleep(0x1b054c0)
        /usr/lib/go/src/runtime/lock_futex.go:151 +0xa2
runtime.stopm()
        /usr/lib/go/src/runtime/proc.go:2016 +0xe3
runtime.findrunnable(0xc000053400, 0x0)
        /usr/lib/go/src/runtime/proc.go:2487 +0x4dc
runtime.schedule()
        /usr/lib/go/src/runtime/proc.go:2613 +0x13a
runtime.park_m(0xc0003aec00)
        /usr/lib/go/src/runtime/proc.go:2676 +0xae
runtime.mcall(0x0)
        /usr/lib/go/src/runtime/asm_amd64.s:299 +0x5b

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc0002f2000, 0x118cd49, 0x20, 0x11ac470, 0xc00023db01)
        /usr/lib/go/src/testing/testing.go:879 +0x689
testing.runTests.func1(0xc0002f2000)
        /usr/lib/go/src/testing/testing.go:1119 +0xa9
testing.tRunner(0xc0002f2000, 0xc00023dd20)
        /usr/lib/go/src/testing/testing.go:827 +0x163
testing.runTests(0xc0002dc700, 0x1afcfe0, 0xa, 0xa, 0x300)
        /usr/lib/go/src/testing/testing.go:1117 +0x4ef
testing.(*M).Run(0xc000184400, 0x0)
        /usr/lib/go/src/testing/testing.go:1034 +0x2ef
main.main()
        _testmain.go:130 +0x333

....
```
Maybe you can help me with that problem? :slightly_smiling_face:  