### PR TITLE
Add service address in the output of cluster call

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -128,6 +128,11 @@ func resourceCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"srv_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"replication_spec": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -258,6 +263,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("mongo_uri", c.MongoURI)
 	d.Set("mongo_uri_updated", c.MongoURIUpdated)
 	d.Set("mongo_uri_with_options", c.MongoURIWithOptions)
+	d.Set("srv_address", c.SrvAddress)
 
 	return nil
 }
@@ -315,6 +321,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		c.MongoURI = ""
 		c.MongoURIWithOptions = ""
 		c.MongoURIUpdated = ""
+		c.SrvAddress = ""
 		_, _, err := client.Clusters.Update(d.Get("group").(string), d.Get("name").(string), c)
 		if err != nil {
 			return fmt.Errorf("Error reading MongoDB Cluster %s: %s", d.Get("name").(string), err)


### PR DESCRIPTION
Add service address, so that it's easy to link acquire a connection string. This addresses issue #67 