### PR TITLE
add region name and cidr block for aws provider for container creation

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_container.go
+++ b/mongodbatlas/resource_mongodbatlas_container.go
@@ -88,6 +88,11 @@ func resourceContainerCreate(d *schema.ResourceData, meta interface{}) error {
 		params.NetworkName = d.Get("network_name").(string)
 	}
 
+	if params.ProviderName == "AWS" {
+		params.RegionName = d.Get("region").(string)
+		params.AtlasCidrBlock = d.Get("atlas_cidr_block").(string)
+	}
+
 	container, _, err := client.Containers.Create(d.Get("group").(string), &params)
 
 	if err != nil {


### PR DESCRIPTION
There was a missing if-Statement to check for the AWS provider name when creating a new container. This caused terraform to fail at creating the container, saying 
`mongodbatlas_container.container: Error creating MongoDB Container: MongoDB Atlas: 400 The required attribute regionName was not specified.
`