### PR TITLE
Fix peering

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
@@ -22,6 +22,15 @@ func resourceVpcPeeringConnection() *schema.Resource {
 			State: resourceVpcPeeringConnectionImportState,
 		},
 
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceVpcPeeringConnectionResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceVpcPeeringConnectionStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"group": {
 				Type:     schema.TypeString,

--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
@@ -300,6 +300,14 @@ func resourceVpcPeeringConnectionImportState(d *schema.ResourceData, meta interf
 		return nil, err
 	}
 
+	// https://docs.atlas.mongodb.com/reference/api/vpc-get-connection/#example-response
+	// Atlas API does not return ProviderName, so we have to guess it from other parameters
+	if peer.AwsAccountID != "" {
+		d.Set("provider_name", "AWS")
+	} else if peer.GcpProjectID != "" {
+		d.Set("provider_name", "GCP")
+	}
+
 	d.SetId(peer.ID)
 	if err := d.Set("group", gid); err != nil {
 		log.Printf("[WARN] Error setting group for (%s): %s", d.Id(), err)

--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection.go
@@ -312,9 +312,13 @@ func resourceVpcPeeringConnectionImportState(d *schema.ResourceData, meta interf
 	// https://docs.atlas.mongodb.com/reference/api/vpc-get-connection/#example-response
 	// Atlas API does not return ProviderName, so we have to guess it from other parameters
 	if peer.AwsAccountID != "" {
-		d.Set("provider_name", "AWS")
+		if err := d.Set("provider_name", "AWS"); err != nil {
+			return nil, fmt.Errorf("Error setting provider name: %v", err)
+		}
 	} else if peer.GcpProjectID != "" {
-		d.Set("provider_name", "GCP")
+		if err := d.Set("provider_name", "GCP"); err != nil {
+			return nil, fmt.Errorf("Error setting provider name: %v", err)
+		}
 	}
 
 	d.SetId(peer.ID)

--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate.go
@@ -1,0 +1,66 @@
+package mongodbatlas
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceVpcPeeringConnectionResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"group": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"route_table_cidr_block": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"aws_account_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"container_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"identifier": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"connection_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"status_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"error_state_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVpcPeeringConnectionStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if v, ok := rawState["provider_name"]; (ok && v == "") || !ok {
+		rawState["provider_name"] = "AWS"
+	}
+
+	return rawState, nil
+}

--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate.go
@@ -7,48 +7,48 @@ import (
 func resourceVpcPeeringConnectionResourceV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"group": &schema.Schema{
+			"group": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"route_table_cidr_block": &schema.Schema{
+			"route_table_cidr_block": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"aws_account_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"vpc_id": &schema.Schema{
+			"aws_account_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"container_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"identifier": &schema.Schema{
+			"container_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-			"connection_id": &schema.Schema{
+			"connection_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-			"status_name": &schema.Schema{
+			"status_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"error_state_name": &schema.Schema{
+			"error_state_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,

--- a/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate_test.go
+++ b/mongodbatlas/resource_mongodbatlas_vpc_peering_connection_migrate_test.go
@@ -1,0 +1,73 @@
+package mongodbatlas
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testResourceVpcPeeringConnectionResourceV0_aws() map[string]interface{} {
+	return map[string]interface{}{
+		"aws_account_id":         "123456789",
+		"connection_id":          "pcx-123wefds43erg34ter",
+		"container_id":           "284nf7ek37g73jr7tj4jr8ei",
+		"error_state_name":       "",
+		"group":                  "812nf72jf82j72j72hejw8yr",
+		"id":                     "7s6b3r7tdsgf7t3igsdft3fu",
+		"identifier":             "7s6b3r7tdsgf7t3igsdft3fu",
+		"route_table_cidr_block": "172.20.0.0/16",
+		"status_name":            "AVAILABLE",
+		"vpc_id":                 "vpc-12345678",
+	}
+}
+
+func testResourceVpcPeeringConnectionResourceV1_aws() map[string]interface{} {
+	v0 := testResourceVpcPeeringConnectionResourceV0_aws()
+	return map[string]interface{}{
+		"aws_account_id":         v0["aws_account_id"],
+		"connection_id":          v0["connection_id"],
+		"container_id":           v0["container_id"],
+		"error_state_name":       v0["error_state_name"],
+		"group":                  v0["group"],
+		"id":                     v0["id"],
+		"identifier":             v0["identifier"],
+		"route_table_cidr_block": v0["route_table_cidr_block"],
+		"status_name":            v0["status_name"],
+		"vpc_id":                 v0["vpc_id"],
+		"provider_name":          "AWS",
+	}
+}
+
+func testResourceVpcPeeringConnectionResourceV0_gce() map[string]interface{} {
+	return map[string]interface{}{
+		"container_id":   "507f1f77bcf86cd799439011",
+		"error_message":  "",
+		"status":         "ADDING_PEER",
+		"gcp_project_id": "my-sample-project-191923",
+		"network_name":   "test1",
+		"provider_name":  "GCP",
+	}
+}
+
+func TestResourceAwsKinesisStreamStateUpgradeV0_aws(t *testing.T) {
+	expected := testResourceVpcPeeringConnectionResourceV1_aws()
+	actual, err := resourceVpcPeeringConnectionStateUpgradeV0(testResourceVpcPeeringConnectionResourceV0_aws(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}
+
+func TestResourceAwsKinesisStreamStateUpgradeV0_gce(t *testing.T) {
+	expected := testResourceVpcPeeringConnectionResourceV0_gce()
+	actual, err := resourceVpcPeeringConnectionStateUpgradeV0(testResourceVpcPeeringConnectionResourceV0_gce(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes issues rised in #94 :
* Sets provider name on import to avoid force recreation
* Adds migration for older AWS resources if a parameter for provider name was empty.