### PR TITLE
feat(project): implement project import

### DIFF
--- a/mongodbatlas/provider_test.go
+++ b/mongodbatlas/provider_test.go
@@ -11,6 +11,7 @@ import (
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 var testAccMongodbAtlasOrgId string
+var testAccMongodbAtlasProjectId string
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
@@ -35,5 +36,9 @@ func testAccPreCheck(t *testing.T) {
 	if testAccMongodbAtlasOrgId = os.Getenv("MONGODB_ATLAS_TESTACC_ORG_ID"); testAccMongodbAtlasOrgId == "" {
 		// default org_id
 		testAccMongodbAtlasOrgId = "5b71ff2f96e82120d0aaec14"
+	}
+	if testAccMongodbAtlasProjectId = os.Getenv("MONGODB_ATLAS_TESTACC_PROJECT_ID"); testAccMongodbAtlasProjectId == "" {
+		// default org_id
+		testAccMongodbAtlasProjectId = "5b71ff2f96e82120d0aaec14"
 	}
 }

--- a/mongodbatlas/provider_test.go
+++ b/mongodbatlas/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
+var testAccMongodbAtlasOrgId string
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
@@ -30,5 +31,9 @@ func testAccPreCheck(t *testing.T) {
 		if v := os.Getenv("MONGODB_ATLAS_API_KEY"); v == "" {
 			t.Fatal("MONGODB_ATLAS_API_KEY must be set for acceptance tests")
 		}
+	}
+	if testAccMongodbAtlasOrgId = os.Getenv("MONGODB_ATLAS_TESTACC_ORG_ID"); testAccMongodbAtlasOrgId == "" {
+		// default org_id
+		testAccMongodbAtlasOrgId = "5b71ff2f96e82120d0aaec14"
 	}
 }

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -14,7 +14,7 @@ func resourceProject() *schema.Resource {
 		Read:   resourceProjectRead,
 		Delete: resourceProjectDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceProjectImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -96,4 +96,30 @@ func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceProjectImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*ma.Client)
+
+	p, _, err := client.Projects.Get(d.Id())
+
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't import project %s, error: %s", d.Id(), err.Error())
+	}
+
+	d.SetId(p.ID)
+
+	if err := d.Set("org_id", p.OrgID); err != nil {
+		log.Printf("[WARN] Error importing org_id for (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("name", p.Name); err != nil {
+		log.Printf("[WARN] Error importing name for (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("created", p.Created); err != nil {
+		log.Printf("[WARN] Error importing created for (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("cluster_count", p.ClusterCount); err != nil {
+		log.Printf("[WARN] Error importing cluster_count for (%s): %s", d.Id(), err)
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -30,7 +30,7 @@ func TestAccMongodbatlasProject_basic(t *testing.T) {
 
 func testAccMongodbatlasProject(projectName string) string {
 	return fmt.Sprintf(`resource "mongodbatlas_project" "test" {
-  org_id = "5b71ff2f96e82120d0aaec14"
+  org_id = "%s"
   name = "%s"
 }`, projectName)
 }

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	ma "github.com/akshaykarle/go-mongodbatlas/mongodbatlas"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccMongodbatlasProject_basic(t *testing.T) {
@@ -28,9 +30,53 @@ func TestAccMongodbatlasProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccProject_importBasic(t *testing.T) {
+	resourceName := "mongodbatlas_project.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongodbatlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongodbatlasProject("test"),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     testAccMongodbAtlasProjectId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccMongodbatlasProject(projectName string) string {
 	return fmt.Sprintf(`resource "mongodbatlas_project" "test" {
   org_id = "%s"
   name = "%s"
-}`, projectName)
+}`, testAccMongodbAtlasOrgId, projectName)
+}
+
+func testAccCheckMongodbatlasProjectDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ma.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_project" {
+			continue
+		}
+
+		projects, _, err := client.Projects.List()
+
+		if err == nil {
+			if len(projects) != 0 {
+				return fmt.Errorf("projects %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if err != nil {
+			return fmt.Errorf("Error listing MongoDB Projects: %s", err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Hello, 

I implement project import, and I had acceptance test. It closes #51 

But I couldn't make acceptance tests worked on my computer for project resource. 

I try my code manually, it worked, but when I run test acceptance I got this : 

`
=== RUN   TestAccProject_importBasic
--- FAIL: TestAccProject_importBasic (2.23s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: mongodbatlas_project.test
          cluster_count: "0" => "<computed>"
          created:       "2019-06-29T20:09:36Z" => "<computed>"
          id:            "5d17c57fa6f239a99dd3c355" => "<computed>"
          name:          "test" => "test"
          org_id:        "5d17c57fa6f239a99dd3c356" => "" (forces new resource)
        
        
        
        STATE:
        
        mongodbatlas_project.test:
          ID = 5d17c57fa6f239a99dd3c355
          provider = provider.mongodbatlas
          cluster_count = 0
          created = 2019-06-29T20:09:36Z
          name = test
          org_id = 5d17c57fa6f239a99dd3c356
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: projects "5d17c57fa6f239a99dd3c355" still exists
        
        State: <no state>
FAIL
`

But when I run basic acceptance test, I got the same issue : 

`
=== RUN   TestAccMongodbatlasProject_basic
--- FAIL: TestAccMongodbatlasProject_basic (2.87s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: mongodbatlas_project.test
          cluster_count: "0" => "<computed>"
          created:       "2019-06-29T20:10:58Z" => "<computed>"
          id:            "5d17c5d2c56c981a2afdeeee" => "<computed>"
          name:          "testAcc" => "testAcc"
          org_id:        "5d17c5d2c56c981a2afdeeef" => "" (forces new resource)
        
        
        
        STATE:
        
        mongodbatlas_project.test:
          ID = 5d17c5d2c56c981a2afdeeee
          provider = provider.mongodbatlas
          cluster_count = 0
          created = 2019-06-29T20:10:58Z
          name = testAcc
          org_id = 5d17c5d2c56c981a2afdeeef
FAIL
`
I don't understand why(and how) terraform plan determine that "org_id" should be empty ? 