### PR TITLE
support custom API base URL

### DIFF
--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -10,11 +10,12 @@ import (
 type Config struct {
 	AtlasUsername string
 	AtlasAPIKey   string
+	AtlasAPIURL   string
 }
 
 func (c *Config) NewClient() *ma.Client {
 	t := dac.NewTransport(c.AtlasUsername, c.AtlasAPIKey)
 	httpClient := &http.Client{Transport: &t}
-	client := ma.NewClient(httpClient)
+	client := ma.NewCustomURLClient(httpClient, c.AtlasAPIURL)
 	return client
 }

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -20,6 +20,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("MONGODB_ATLAS_API_KEY", ""),
 				Description: "MongoDB Atlas API Key",
 			},
+			"api_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("MONGODB_ATLAS_API_URL", "https://cloud.mongodb.com/api/atlas/v1.0/"),
+				Description: "MongoDB Atlas API base url",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -45,6 +51,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AtlasUsername: d.Get("username").(string),
 		AtlasAPIKey:   d.Get("api_key").(string),
+		AtlasAPIURL:   d.Get("api_url").(string),
 	}
 
 	client := config.NewClient()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -82,3 +82,7 @@ Atlas `provider` block:
 * `username` - (Optional) This is the MongoDB Atlas username. It must be
   provided, but it can also be sourced from the `MONGODB_ATLAS_USERNAME`
   environment variable.
+
+* `api_url` - (Optional) This is the MongoDB API base URL. It can also be
+  sourced from the `MONGODB_ATLAS_API_URL` environment variable. Default
+  value is `https://cloud.mongodb.com/api/atlas/v1.0`.


### PR DESCRIPTION
The new argument `api_url` let users to use this provider with custom rest API base URL. (e.g. URL for Cloud Manager or Ops Manager.) It depends on https://github.com/akshaykarle/go-mongodbatlas/pull/20 and I think `vendor` should be updated after that PR is merge.